### PR TITLE
[WIP] Importing cell timings from prjxray-db

### DIFF
--- a/fpga_interchange/chip_info.py
+++ b/fpga_interchange/chip_info.py
@@ -568,14 +568,20 @@ class CellConstraint():
         bba.u32(len(self.states))
 
 
+class PinEdgeType(Enum):
+    NONE = 0
+    RISE = 1
+    FALL = 2
+
+
 class PinEdge():
     def __init__(self):
         self.pin_name = ""
-        self.clock_edge = 0
+        self.clock_edge = PinEdgeType.NONE
 
     def append_bba(self, bba, label_prefix):
         bba.str_id(self.pin_name)
-        bba.u32(self.clock_edge)
+        bba.u32(self.clock_edge.value)
 
 
 class TimingCorners():
@@ -606,6 +612,9 @@ class PinTiming():
         self.type = PinTimingType.COMB
         self.value = TimingCorners()
         self.site_type_idx = 0
+
+    def append_children_bba(self, bba, label_prefix):
+        pass
 
     def append_bba(self, bba, label_prefix):
         self.from_pin.append_bba(bba, label_prefix)

--- a/fpga_interchange/chip_info.py
+++ b/fpga_interchange/chip_info.py
@@ -176,6 +176,8 @@ class TileWireInfo():
         # -1 if site is a primary type, otherwise index into altSiteTypes.
         self.site_variant = 0
 
+        self.timing_idx = -1
+
     def field_label(self, label_prefix, field):
         if self.site != -1:
             prefix = '{}.site{}.{}.{}'.format(label_prefix, self.site,
@@ -210,6 +212,7 @@ class TileWireInfo():
 
         bba.u16(self.site)
         bba.u16(self.site_variant)
+        bba.u32(self.timing_idx)
 
 
 class PipInfo():

--- a/fpga_interchange/chip_info.py
+++ b/fpga_interchange/chip_info.py
@@ -231,6 +231,10 @@ class PipInfo():
 
         self.extra_data = 0
 
+        # Timing info
+        self.timing_idx = -1
+        self.is_buffered = 0
+
         self.pseudo_cell_wires = []
 
     def field_label(self, label_prefix, field):
@@ -253,6 +257,9 @@ class PipInfo():
         bba.u16(self.site_variant)
         bba.u16(self.bel)
         bba.u16(self.extra_data)
+        bba.u32(self.timing_idx)
+        bba.u16(self.is_buffered)
+        bba.u16(0)  # padding
         bba.ref(self.field_label(label_prefix, 'pseudo_cell_wires'))
         bba.u32(len(self.pseudo_cell_wires))
 
@@ -478,6 +485,7 @@ class TileWireRef():
 class NodeInfo():
     def __init__(self):
         self.name = ''
+        self.timing_idx = -1
         self.tile_wires = []
 
     def tile_wires_label(self, label_prefix):
@@ -490,6 +498,7 @@ class NodeInfo():
             tile_wire.append_bba(bba, label)
 
     def append_bba(self, bba, label_prefix):
+        bba.u32(self.timing_idx)
         bba.ref(self.tile_wires_label(label_prefix))
         bba.u32(len(self.tile_wires))
 
@@ -556,15 +565,66 @@ class CellConstraint():
         bba.u32(len(self.states))
 
 
+class PinEdge():
+    def __init__(self):
+        self.pin_name = ""
+        self.clock_edge = 0
+
+    def append_bba(self, bba, label_prefix):
+        bba.str_id(self.pin_name)
+        bba.u32(self.clock_edge)
+
+
+class TimingCorners():
+    def __init__(self):
+        self.fast_min = 0
+        self.fast_max = 0
+        self.slow_min = 0
+        self.slow_max = 0
+
+    def append_bba(self, bba, label_prefix):
+        bba.u32(self.fast_min)
+        bba.u32(self.fast_max)
+        bba.u32(self.slow_min)
+        bba.u32(self.slow_max)
+
+
+class PinTimingType(Enum):
+    COMB = 0
+    SETUP = 1
+    HOLD = 2
+    CLK2Q = 3
+
+
+class PinTiming():
+    def __init__(self):
+        self.from_pin = PinEdge()
+        self.to_pin = PinEdge()
+        self.type = PinTimingType.COMB
+        self.value = TimingCorners()
+        self.site_type_idx = 0
+
+    def append_bba(self, bba, label_prefix):
+        self.from_pin.append_bba(bba, label_prefix)
+        self.to_pin.append_bba(bba, label_prefix)
+        bba.u32(self.type.value)
+        self.value.append_bba(bba, label_prefix)
+        bba.u32(self.site_type_idx)
+
+
 class CellBelMap():
-    fields = ['common_pins', 'parameter_pins', 'constraints']
-    field_types = ['CellBelPinPOD', 'ParameterPinsPOD', 'CellConstraintPOD']
+    fields = ['common_pins', 'parameter_pins', 'constraints', 'timing']
+    field_types = [
+        'CellBelPinPOD', 'ParameterPinsPOD', 'CellConstraintPOD',
+        'PinTimingPOD'
+    ]
 
     def __init__(self, cell, tile_type, site_index, bel):
         self.key = '_'.join((cell, tile_type, str(site_index), bel))
         self.common_pins = []
         self.parameter_pins = []
         self.constraints = []
+        self.timing = []
 
     def field_label(self, label_prefix, field):
         prefix = '{}.{}.{}'.format(label_prefix, self.key, field)
@@ -1013,6 +1073,36 @@ class Package():
         bba.u32(len(self.package_pins))
 
 
+class PipTiming():
+    def __init__(self):
+        self.int_cap = TimingCorners()
+        self.int_delay = TimingCorners()
+        self.out_res = TimingCorners()
+        self.out_cap = TimingCorners()
+
+    def append_children_bba(self, bba, label_prefix):
+        pass
+
+    def append_bba(self, bba, label_prefix):
+        self.int_cap.append_bba(bba, label_prefix)
+        self.int_delay.append_bba(bba, label_prefix)
+        self.out_res.append_bba(bba, label_prefix)
+        self.out_cap.append_bba(bba, label_prefix)
+
+
+class NodeTiming():
+    def __init__(self):
+        self.res = TimingCorners()
+        self.cap = TimingCorners()
+
+    def append_children_bba(self, bba, label_prefix):
+        pass
+
+    def append_bba(self, bba, label_prefix):
+        self.res.append_bba(bba, label_prefix)
+        self.cap.append_bba(bba, label_prefix)
+
+
 class DefaultCellConnection():
     def __init__(self):
         self.name = ''
@@ -1381,6 +1471,8 @@ class ChipInfo():
         self.wire_types = []
         self.global_cells = []
         self.clusters = []
+        self.node_timings = []
+        self.pip_timings = []
 
         # str, constids
         self.bel_buckets = []
@@ -1396,19 +1488,14 @@ class ChipInfo():
 
         children_fields = [
             'tile_types', 'sites', 'tiles', 'nodes', 'packages', 'wire_types',
-            'global_cells', 'macros', 'macro_rules', 'clusters'
+            'global_cells', 'macros', 'macro_rules', 'clusters',
+            'node_timings', 'pip_timings'
         ]
         children_types = [
-            'TileTypeInfoPOD',
-            'SiteInstInfoPOD',
-            'TileInstInfoPOD',
-            'NodeInfoPOD',
-            'PackagePOD',
-            'WireTypePOD',
-            'GlobalCellPOD',
-            'MacroPOD',
-            'MacroExpansionPOD',
-            'ClusterPOD',
+            'TileTypeInfoPOD', 'SiteInstInfoPOD', 'TileInstInfoPOD',
+            'NodeInfoPOD', 'PackagePOD', 'WireTypePOD', 'GlobalCellPOD',
+            'MacroPOD', 'MacroExpansionPOD', 'ClusterPOD', 'NodeTimingPOD',
+            'PipTimingPOD'
         ]
         for field, field_type in zip(children_fields, children_types):
             prefix = '{}.{}'.format(label, field)

--- a/fpga_interchange/device_timing_patching.py
+++ b/fpga_interchange/device_timing_patching.py
@@ -228,6 +228,7 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
     if site not in pins_delay:
         pins_delay[site] = dict()
 
+    used_pins = set()
     for path_name, path in timings.items():
 
         if path["from_pin"] not in pins or path["to_pin"] not in pins:
@@ -241,6 +242,9 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
             if pin_2 is None:
                 print("WARNING: unknown bel pin '{}.{}'".format(bel, path["to_pin"]))
             continue
+
+        for key in ["from_pin", "to_pin"]:
+            used_pins.add(path[key])
 
         # Take the slow and fast corner
         delays = path["delay_paths"]
@@ -293,6 +297,10 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
     if not pins_delay[site]:
         del pins_delay[site]
 
+    # Report missing pin timings
+    if pins != used_pins:
+        missing_pins = sorted(list(pins - used_pins))
+        print("WARNING: no timings for BEL pins:", ",".join(missing_pins))
 
 def main():
     parser = argparse.ArgumentParser(

--- a/fpga_interchange/device_timing_patching.py
+++ b/fpga_interchange/device_timing_patching.py
@@ -97,6 +97,7 @@ def create_site_type_name_to_site_pin_map(device):
             siteType_name_sitePin[(i, sitePin.name)] = sitePin
     return siteType_name_sitePin
 
+
 def create_bel_pin_to_index_map(device):
     bel_pin_to_index = dict()
 
@@ -113,6 +114,7 @@ def create_bel_pin_to_index_map(device):
             bel_pin_to_index[site_type][bel][pin] = j
 
     return bel_pin_to_index
+
 
 def populate_corner_model(corner_model, fast_min, fast_typ, fast_max, slow_min,
                           slow_typ, slow_max):
@@ -131,6 +133,7 @@ def populate_corner_model(corner_model, fast_min, fast_typ, fast_max, slow_min,
         if slow[i] is not None:
             x = getattr(corner_model.slow.slow, field)
             setattr(x, field, slow[i])
+
 
 def populate_pin_delays(cell_bel_mapping, timings, string_map):
     """
@@ -203,23 +206,28 @@ def populate_pin_delays(cell_bel_mapping, timings, string_map):
         entry.init("cornerModel")
         corner_model = entry.cornerModel
 
-        delays_slow = timing["delays"].get("slow",
-            {"min": None, "typ": None, "max": None})
+        delays_slow = timing["delays"].get("slow", {
+            "min": None,
+            "typ": None,
+            "max": None
+        })
 
-        delays_fast = timing["delays"].get("fast",
-            {"min": None, "typ": None, "max": None})
+        delays_fast = timing["delays"].get("fast", {
+            "min": None,
+            "typ": None,
+            "max": None
+        })
 
-        populate_corner_model(corner_model,
-            delays_fast.get("min", None),
-            delays_fast.get("typ", None),
-            delays_fast.get("max", None),
-            delays_slow.get("min", None),
-            delays_slow.get("typ", None),
-            delays_slow.get("max", None)
-        )
+        populate_corner_model(corner_model, delays_fast.get("min", None),
+                              delays_fast.get("typ", None),
+                              delays_fast.get("max", None),
+                              delays_slow.get("min", None),
+                              delays_slow.get("typ", None),
+                              delays_slow.get("max", None))
 
 
-def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_pin_to_index_map):
+def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins,
+                       bel_pin_to_index_map):
     """
     Collects timing data for the given cell type and cell bel pin mapping.
     Matches the SDF data against device resources data. Converts BEL pin names
@@ -241,7 +249,8 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
         timings = cell_timing_data[site][bel].get(None, None)
 
     if timings is None:
-        print("WARNING: not timing data for cell '{}' at site/bel '{}/{}'".format(cell, site, bel))
+        print("WARNING: not timing data for cell '{}' at site/bel '{}/{}'".
+              format(cell, site, bel))
         return
 
     # Translate the timing data
@@ -257,12 +266,14 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
             continue
 
         pin_1 = bel_pin_to_index_map[site][bel].get(path["from_pin"], None)
-        pin_2 = bel_pin_to_index_map[site][bel].get(path["to_pin"],   None)
+        pin_2 = bel_pin_to_index_map[site][bel].get(path["to_pin"], None)
         if pin_1 is None or pin_2 is None:
             if pin_1 is None:
-                print("WARNING: unknown bel pin '{}.{}'".format(bel, path["from_pin"]))
+                print("WARNING: unknown bel pin '{}.{}'".format(
+                    bel, path["from_pin"]))
             if pin_2 is None:
-                print("WARNING: unknown bel pin '{}.{}'".format(bel, path["to_pin"]))
+                print("WARNING: unknown bel pin '{}.{}'".format(
+                    bel, path["to_pin"]))
             continue
 
         for key in ["from_pin", "to_pin"]:
@@ -299,7 +310,9 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
             for k2 in corner[k1].keys():
                 val = corner[k1][k2]
                 if val < 0.0:
-                    print("WARNING: delay for path '{}' {} {} is negative ({:.3f}ps), clamping to 0".format(path_name, k1, k2, val * 1e12))
+                    print(
+                        "WARNING: delay for path '{}' {} {} is negative ({:.3f}ps), clamping to 0"
+                        .format(path_name, k1, k2, val * 1e12))
                     corner[k1][k2] = 0.0
 
         if bel not in pins_delay[site]:
@@ -307,7 +320,8 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
 
         # Warn before overwrite
         if path_name in pins_delay[site][bel]:
-            print("WARNING: overwriting timing path '{}' for site/bel '{}/{}'".format(path_name, site, bel))
+            print("WARNING: overwriting timing path '{}' for site/bel '{}/{}'".
+                  format(path_name, site, bel))
 
         # Format the entry
         data = {
@@ -331,6 +345,7 @@ def collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_
     if pins != used_pins:
         missing_pins = sorted(list(pins - used_pins))
         print("WARNING: no timings for BEL pins:", ",".join(missing_pins))
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -390,12 +405,13 @@ def main():
             pins = set()
             for entry in pin_map.pins:
                 pins.add(dev.strList[entry.belPin])
-                
+
             for entry in pin_map.siteTypes:
                 site = dev.strList[entry.siteType]
                 for bel_i in entry.bels:
                     bel = dev.strList[bel_i]
-                    collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_pin_to_index_map)
+                    collect_pins_delay(pins_delay, cell_timing_data, cell,
+                                       site, bel, pins, bel_pin_to_index_map)
 
         # Parameter pins
         for pin_map in mapping.parameterPins:
@@ -407,7 +423,8 @@ def main():
             for entry in pin_map.parametersSiteTypes:
                 site = dev.strList[entry.siteType]
                 bel = dev.strList[entry.bel]
-                collect_pins_delay(pins_delay, cell_timing_data, cell, site, bel, pins, bel_pin_to_index_map)
+                collect_pins_delay(pins_delay, cell_timing_data, cell, site,
+                                   bel, pins, bel_pin_to_index_map)
 
         # No entries
         if not pins_delay:
@@ -428,7 +445,6 @@ def main():
 
         # Serialize
         populate_pin_delays(mapping, pins_delay_flat, string_map)
-                
 
     for tile, _data in timing_data.items():
         if tile not in string_map:

--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -18,7 +18,8 @@ from fpga_interchange.chip_info import ChipInfo, BelShortedPins, BelInfo, TileTy
         CellConstraint, ConstraintType, Package, PackagePin, LutCell, \
         LutElement, LutBel, CellParameter, DefaultCellConnections, DefaultCellConnection, \
         WireType, Macro, MacroNet, MacroPortInst, MacroCellInst, MacroExpansion, \
-        MacroParamMapRule, MacroParamRuleType, MacroParameter, GlobalCell, GlobalCellPin, Cluster
+        MacroParamMapRule, MacroParamRuleType, MacroParameter, GlobalCell, GlobalCellPin, Cluster, TimingCorners, PipTiming, \
+        NodeTiming
 from fpga_interchange.constraints.model import Tag, Placement, \
         ImpliesConstraint, RequiresConstraint, SiteTypeMatcher
 from fpga_interchange.constraint_generator import ConstraintPrototype
@@ -27,6 +28,7 @@ import fpga_interchange.device_resources
 from fpga_interchange.nextpnr import PortType
 from fpga_interchange.logical_netlist import PortInstance, Net
 from fpga_interchange.device_resources import Direction
+from fpga_interchange.static_timing_analysis import SECOND_CHOICE, ALL_POSSIBLE_VALUES
 
 
 class FlattenedWireType(Enum):
@@ -99,8 +101,8 @@ class FlattenedWire():
 class FlattenedPip(
         namedtuple(
             'FlattenedPip',
-            'type src_index dst_index site_index pip_index pseudo_cell_wires is_buffered timing_idx')
-):
+            'type src_index dst_index site_index pip_index pseudo_cell_wires is_buffered timing_idx'
+        )):
     pass
 
 
@@ -110,6 +112,40 @@ class FlattenedSite(
             'site_in_type_index site_type_index site_type site_type_name site_variant bel_to_bel_index bel_pin_to_site_wire_index bel_pin_index_to_bel_index'
         )):
     pass
+
+
+def import_corner(corner_model, scale=1.0):
+    result = TimingCorners()
+
+    def get_value_from_model(req_process, req_corner):
+        process = getattr(corner_model, req_process)
+        if process.which() == req_process:
+            process = getattr(process, req_process)
+            corner = getattr(process, req_corner)
+            if corner.which() == req_corner:
+                return getattr(corner, req_corner)
+            for corner in ALL_POSSIBLE_VALUES:
+                if getattr(process, corner).which() == corner:
+                    return getattr(getattr(process, corner), corner)
+        process = getattr(corner_model, SECOND_CHOICE[req_process])
+        if process.which() == SECOND_CHOICE[req_process]:
+            process = getattr(process, SECOND_CHOICE[req_process])
+            corner = getattr(process, req_corner)
+            if corner.which() == req_corner:
+                return getattr(corner, req_corner)
+            for corner in ALL_POSSIBLE_VALUES:
+                if getattr(process, corner).which() == corner:
+                    return getattr(getattr(process, corner), corner)
+        else:
+            return 0
+
+    for process in ("fast", "slow"):
+        for corner in ("min", "max"):
+            val = get_value_from_model(process, corner)
+            val = int(val * scale)
+            assert val >= 0 and val < 0x7FFFFFFF
+            setattr(result, f"{process}_{corner}", val)
+    return result
 
 
 def emit_constraints(tile_type, tile_constraints, cell_bel_mapper):
@@ -238,7 +274,8 @@ class FlattenedTileType():
                 # Skip pseudo pips through disabled cells
                 continue
 
-            pip_index = self.add_tile_pip(idx, pip.wire0, pip.wire1, pip.timing, pip.buffered20)
+            pip_index = self.add_tile_pip(idx, pip.wire0, pip.wire1,
+                                          pip.timing, pip.buffered20)
 
             if is_pseudo_cell:
                 pseudo_pips.append((pip_index, pip))
@@ -247,7 +284,8 @@ class FlattenedTileType():
                 # Pseudo pips should not be bidirectional!
                 assert not is_pseudo_cell
 
-                self.add_tile_pip(idx, pip.wire1, pip.wire0, pip.timing, pip.buffered21)
+                self.add_tile_pip(idx, pip.wire1, pip.wire0, pip.timing,
+                                  pip.buffered21)
 
         # Add all site variants
         for site_in_type_index, site_type_in_tile_type in enumerate(
@@ -437,7 +475,12 @@ class FlattenedTileType():
 
         return pip_index
 
-    def add_tile_pip(self, tile_pip_index, src_wire, dst_wire, timing_idx=-1, is_buffered=True):
+    def add_tile_pip(self,
+                     tile_pip_index,
+                     src_wire,
+                     dst_wire,
+                     timing_idx=-1,
+                     is_buffered=True):
         assert self.wires[src_wire].type == FlattenedWireType.TILE_WIRE
         assert self.wires[dst_wire].type == FlattenedWireType.TILE_WIRE
 
@@ -754,6 +797,9 @@ class FlattenedTileType():
             pip_info.src_index = pip.src_index
             pip_info.dst_index = pip.dst_index
             pip_info.pseudo_cell_wires = pip.pseudo_cell_wires
+
+            pip_info.timing_idx = pip.timing_idx
+            pip_info.is_buffered = pip.is_buffered
 
             if pip.site_index is not None:
                 site = self.sites[pip.site_index]
@@ -2233,6 +2279,11 @@ def populate_macro_rules(device, chip_info):
         chip_info.macro_rules.append(exp_data)
 
 
+CAP_SCALE = 1e15  # fF
+RES_SCALE = 1e6  # uOhm
+DEL_SCALE = 1e12  # ps
+
+
 def populate_chip_info(device, constids, device_config):
     assert len(constids.values) == 1
 
@@ -2572,5 +2623,23 @@ def populate_chip_info(device, constids, device_config):
                                                   False) else 0
             global_cell_data.pins.append(pin_data)
         chip_info.global_cells.append(global_cell_data)
+
+    for pip_timing in device.device_resource_capnp.pipTimings:
+        pip_tmg_data = PipTiming()
+        pip_tmg_data.int_cap = import_corner(pip_timing.internalCapacitance,
+                                             CAP_SCALE)
+        pip_tmg_data.int_delay = import_corner(pip_timing.internalDelay,
+                                               DEL_SCALE)
+        pip_tmg_data.out_res = import_corner(pip_timing.outputResistance,
+                                             RES_SCALE)
+        pip_tmg_data.out_cap = import_corner(pip_timing.outputCapacitance,
+                                             CAP_SCALE)
+        chip_info.pip_timings.append(pip_tmg_data)
+
+    for node_timing in device.device_resource_capnp.nodeTimings:
+        node_tmg_data = NodeTiming()
+        node_tmg_data.res = import_corner(node_timing.resistance, RES_SCALE)
+        node_tmg_data.cap = import_corner(node_timing.capacitance, CAP_SCALE)
+        chip_info.node_timings.append(node_tmg_data)
 
     return chip_info

--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -2539,6 +2539,17 @@ def populate_chip_info(device, constids, device_config):
     for idx, node in enumerate(device.device_resource_capnp.nodes):
         # Skip nodes with only 1 wire!
         if len(node.wires) == 1:
+            # Move timing index to tile type
+            wire = device.device_resource_capnp.wires[node.wires[0]]
+            tile_name = device.strs[wire.tile]
+            wire_name = device.strs[wire.wire]
+
+            tile_index = tile_name_to_tile_index[tile_name]
+            tile_info = chip_info.tiles[tile_index]
+            wire_in_tile_id = tile_wire_to_wire_in_tile_index[tile_info.
+                                                              type][wire_name]
+            chip_info.tile_types[tile_info.type].wire_data[
+                wire_in_tile_id].timing_idx = node.nodeTiming
             continue
 
         node_info = NodeInfo()

--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -898,7 +898,8 @@ class CellBelMapper():
         self.site_type_to_site_type_index = {}
         self.timings = {}
 
-        for i, site_type in enumerate(device.device_resource_capnp.siteTypeList):
+        for i, site_type in enumerate(
+                device.device_resource_capnp.siteTypeList):
             self.site_type_to_site_type_index[site_type.name] = i
 
         for cell_bel_map in device.device_resource_capnp.cellBelMap:
@@ -981,13 +982,16 @@ class CellBelMapper():
             site_type_list = device.device_resource_capnp.siteTypeList
             for pins_delay in cell_bel_map.pinsDelay:
                 site_type = device.strs[pins_delay.site]
-                site_type_index = self.site_type_to_site_type_index[pins_delay.site]
+                site_type_index = self.site_type_to_site_type_index[pins_delay.
+                                                                    site]
 
                 pin_delay_1 = pins_delay.firstPin
                 pin_delay_2 = pins_delay.secondPin
 
-                pin_1 = site_type_list[site_type_index].belPins[pin_delay_1.pin]
-                pin_2 = site_type_list[site_type_index].belPins[pin_delay_2.pin]
+                pin_1 = site_type_list[site_type_index].belPins[pin_delay_1.
+                                                                pin]
+                pin_2 = site_type_list[site_type_index].belPins[pin_delay_2.
+                                                                pin]
 
                 bel_1 = pin_1.bel
                 bel_2 = pin_2.bel
@@ -1015,7 +1019,8 @@ class CellBelMapper():
                 typ = str(pins_delay.pinsDelayType).upper()
                 pin_timing.type = PinTimingType[typ]
 
-                pin_timing.value = import_corner(pins_delay.cornerModel, DEL_SCALE)
+                pin_timing.value = import_corner(pins_delay.cornerModel,
+                                                 DEL_SCALE)
                 pin_timing.site_type_idx = site_type_index
 
                 key = cell_type, site_type, bel

--- a/fpga_interchange/prjxray_db_reader.py
+++ b/fpga_interchange/prjxray_db_reader.py
@@ -89,7 +89,8 @@ def get_timings(site, spec, sdf_data):
         return None
 
     if bel not in sdf_data[cell][site]:
-        print("ERROR: No SDF data for cell '{}', site '{}', bel '{}'".format(cell, site, bel))
+        print("ERROR: No SDF data for cell '{}', site '{}', bel '{}'".format(
+            cell, site, bel))
         return None
 
     return sdf_data[cell][site][bel]
@@ -137,18 +138,18 @@ def merge_timings(timings, overlay):
 
     return walk(timings, overlay)
 
+
 # =============================================================================
 
 
 class prjxray_db_reader:
-    def __init__(self, timing_dir, sdf_map_file = None):
+    def __init__(self, timing_dir, sdf_map_file=None):
         self.timing_dir = timing_dir
 
         self.sdf_map = dict()
         if sdf_map_file is not None:
             with open(sdf_map_file, "r") as fp:
                 self.sdf_map = json.load(fp)
-
 
     def extract_data(self):
 
@@ -301,7 +302,6 @@ class prjxray_db_reader:
 
         return return_dict, timings_dict
 
-
     def process_sdf_data(self, data):
 
         # Timescale. Assume 1ns if not present in the header
@@ -332,8 +332,15 @@ class prjxray_db_reader:
                     site, bel = instance, None
 
                 # Filter timing data
-                keys = {"type", "from_pin", "to_pin", "from_pin_edge", "to_pin_edge", "delay_paths"}
-                paths = {t: {k: v for k, v in d.items() if k in keys} for t, d in paths.items()}
+                keys = {
+                    "type", "from_pin", "to_pin", "from_pin_edge",
+                    "to_pin_edge", "delay_paths"
+                }
+                paths = {
+                    t: {k: v
+                        for k, v in d.items() if k in keys}
+                    for t, d in paths.items()
+                }
 
                 # Apply timescale
                 for key, path in paths.items():
@@ -353,14 +360,12 @@ if __name__ == "__main__":
         "--db-root",
         type=str,
         required=True,
-        help="Project XRay database root path"
-    )
+        help="Project XRay database root path")
     parser.add_argument(
         "--sdf-map",
         type=str,
         required=True,
-        help="Map of SDF timing entries to cell @ site and bel"
-    )
+        help="Map of SDF timing entries to cell @ site and bel")
 
     args = parser.parse_args()
 

--- a/fpga_interchange/prjxray_db_reader.py
+++ b/fpga_interchange/prjxray_db_reader.py
@@ -122,13 +122,16 @@ def merge_timings(timings, overlay):
 
 
 class prjxray_db_reader:
-    def __init__(self, timing_dir):
+    def __init__(self, timing_dir, sdf_map_file = None):
         self.timing_dir = timing_dir
 
-    def extract_data(self, sdf_map=None):
+        self.sdf_map = dict()
+        if sdf_map_file is not None:
+            with open(sdf_map_file, "r") as fp:
+                self.sdf_map = json.load(fp)
 
-        if sdf_map is None:
-            sdf_map = dict()
+
+    def extract_data(self):
 
         return_dict = {}
         for i, _file in enumerate(os.listdir(self.timing_dir)):
@@ -231,7 +234,7 @@ class prjxray_db_reader:
 
         # Collect timings
         timings_dict = dict()
-        for site, site_data in sdf_map.items():
+        for site, site_data in self.sdf_map.items():
 
             if site not in timings_dict:
                 timings_dict[site] = dict()
@@ -337,13 +340,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # Load SDF map
-    with open(args.sdf_map, "r") as fp:
-        sdf_map = json.load(fp)
-
     # Get data
-    reader = prjxray_db_reader(args.db_root)
-    routing_data, timings_dict = reader.extract_data(sdf_map)
+    reader = prjxray_db_reader(args.db_root, args.sdf_map)
+    routing_data, timings_dict = reader.extract_data()
 
     # Dump data (not all of it of course)
     print("Routing timing:")

--- a/fpga_interchange/prjxray_db_reader.py
+++ b/fpga_interchange/prjxray_db_reader.py
@@ -84,6 +84,7 @@ def get_timings(site, spec, sdf_data):
 
     if site not in sdf_data[cell]:
         print("ERROR: No SDF data for cell '{}', site '{}'".format(cell, site))
+        print(sdf_data[cell].keys())
         return None
 
     if bel not in sdf_data[cell][site]:
@@ -247,7 +248,7 @@ class prjxray_db_reader:
             timings = sdfparse.parse(sdf)
             timings = self.process_sdf_data(timings)
 
-            sdf_data.update(timings)
+            sdf_data = merge_timings(sdf_data, timings)
 
         # Collect timings
         timings_dict = dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pyyaml
 yapf==0.24.0
 # TODO: https://github.com/SymbiFlow/python-fpga-interchange/issues/11
 git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml
+git+https://github.com/SymbiFlow/python-sdf-timing@99410bd
 -e .

--- a/test_data/series7_sdf_map.json
+++ b/test_data/series7_sdf_map.json
@@ -1,0 +1,344 @@
+{
+    "SLICEL": {
+        "[ABCD][5]LUT": {
+            "default": [
+                "LUT5@SLICEL/{bel}"
+            ]
+        },
+        "[ABCD][6]LUT": {
+            "default": [
+                "LUT6@SLICEL/{bel}"
+            ]
+        },
+        "[ABCD][5]FF": {
+            "pin_map": {
+                "CLK": "CK",
+                "DIN": "D"
+            },
+            "default": [
+                "REG_INIT_FF@{site}",
+                "REG_INIT_FF_QL@{site}"
+            ]
+        },
+        "[ABCD]FF": {
+            "pin_map": {
+                "CLK": "CK",
+                "DIN": "D"
+            },
+            "default": [
+                "REG_INIT_FF@{site}",
+                "REG_INIT_FF_QL@{site}"
+            ]
+        },
+
+        "CARRY4": {
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_AX@{site}",
+                "CARRY4_BX@{site}",
+                "CARRY4_CX@{site}",
+                "CARRY4_DX@{site}"
+            ]
+        },
+
+        "CARRY4_AMUX": {
+            "pin_map": {
+                "S0": "S0",
+                "DI0": "0",
+                "CYINIT": "1",
+                "CO0": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_AX@{site}"
+            ]
+        },
+        "CARRY4_BMUX": {
+            "pin_map": {
+                "S1": "S0",
+                "DI1": "0",
+                "CO1": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_BX@{site}"
+            ]
+        },
+        "CARRY4_CMUX": {
+            "pin_map": {
+                "S2": "S0",
+                "DI2": "0",
+                "CO2": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_CX@{site}"
+            ]
+        },
+        "CARRY4_DMUX": {
+            "pin_map": {
+                "S3": "S0",
+                "DI3": "0",
+                "CO3": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_DX@{site}"
+            ]
+        },
+
+        "CARRY4_AXOR": {
+            "pin_map": {
+                "S0": "0",
+                "CYINIT": "1",
+                "O0": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_AX@{site}"
+            ]
+        },
+        "CARRY4_BXOR": {
+            "pin_map": {
+                "S1": "0",
+                "O1": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_BX@{site}"
+            ]
+        },
+        "CARRY4_CXOR": {
+            "pin_map": {
+                "S2": "0",
+                "O2": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_CX@{site}"
+            ]
+        },
+        "CARRY4_DXOR": {
+            "pin_map": {
+                "S3": "0",
+                "O3": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_DX@{site}"
+            ]
+        },
+
+        "F7[AB]MUX": {
+            "default": [
+                "SELMUX2_1@{site}/{bel}"
+            ]
+        },
+        "F8MUX": {
+            "default": [
+                "SELMUX2_1@{site}/{bel}"
+            ]
+        }
+    },
+
+    "SLICEM": {
+        "[ABCD]5LUT": {
+            "default": [
+                "LUT5@SLICEL/{bel}"
+            ],
+            "SRL16E": [
+                "LUT_OR_MEM5LRAM@{site}",
+                "LUT_OR_MEM5LRAM@{site}/{bel}",
+                "LUT_OR_MEM5SHFREG@{site}",
+                "LUT_OR_MEM5SHFREG@{site}/{bel}"
+            ],
+            "RAMS32": [
+                "LUT_OR_MEM5LRAM@{site}",
+                "LUT_OR_MEM5LRAM@{site}/{bel}"
+            ],
+            "RAMD32": [
+                "LUT_OR_MEM5LRAM@{site}",
+                "LUT_OR_MEM5LRAM@{site}/{bel}"
+            ]
+        },
+        "[ABCD]6LUT": {
+            "default": [
+                "LUT6@SLICEL/{bel}"
+            ],
+            "SRLC32E": [
+                "LUT_OR_MEM6LRAM@{site}",
+                "LUT_OR_MEM6LRAM@{site}/{bel}",
+                "LUT_OR_MEM6SHFREG@{site}",
+                "LUT_OR_MEM6SHFREG@{site}/{bel}"
+            ],
+            "SRLC16E": [
+                "LUT_OR_MEM6LRAM@{site}",
+                "LUT_OR_MEM6LRAM@{site}/{bel}",
+                "LUT_OR_MEM6SHFREG@{site}",
+                "LUT_OR_MEM6SHFREG@{site}/{bel}"
+            ],
+            "SRL16E": [
+                "LUT_OR_MEM6LRAM@{site}",
+                "LUT_OR_MEM6LRAM@{site}/{bel}",
+                "LUT_OR_MEM6SHFREG@{site}",
+                "LUT_OR_MEM6SHFREG@{site}/{bel}"
+            ],
+            "RAMS32": [
+                "LUT_OR_MEM6LRAM@{site}",
+                "LUT_OR_MEM6LRAM@{site}/{bel}"
+            ],
+            "RAMD32": [
+                "LUT_OR_MEM6LRAM@{site}",
+                "LUT_OR_MEM6LRAM@{site}/{bel}"
+            ],
+            "RAMS64E": [
+                "LUT_OR_MEM6LRAM@{site}",
+                "LUT_OR_MEM6LRAM@{site}/{bel}"
+            ],
+            "RAMD64E": [
+                "LUT_OR_MEM6LRAM@{site}",
+                "LUT_OR_MEM6LRAM@{site}/{bel}"
+            ]
+        },
+        "[ABCD][5]FF": {
+            "pin_map": {
+                "CLK": "CK",
+                "DIN": "D"
+            },
+            "default": [
+                "REG_INIT_FF@{site}",
+                "REG_INIT_FF_QL@{site}"
+            ]
+        },
+        "[ABCD]FF": {
+            "pin_map": {
+                "CLK": "CK",
+                "DIN": "D"
+            },
+            "default": [
+                "REG_INIT_FF@{site}",
+                "REG_INIT_FF_QL@{site}"
+            ]
+        },
+
+        "CARRY4": {
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_AX@{site}",
+                "CARRY4_BX@{site}",
+                "CARRY4_CX@{site}",
+                "CARRY4_DX@{site}"
+            ]
+        },
+
+        "CARRY4_AMUX": {
+            "pin_map": {
+                "S0": "S0",
+                "DI0": "0",
+                "CYINIT": "1",
+                "CO0": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_AX@{site}"
+            ]
+        },
+        "CARRY4_BMUX": {
+            "pin_map": {
+                "S1": "S0",
+                "DI1": "0",
+                "CO1": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_BX@{site}"
+            ]
+        },
+        "CARRY4_CMUX": {
+            "pin_map": {
+                "S2": "S0",
+                "DI2": "0",
+                "CO2": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_CX@{site}"
+            ]
+        },
+        "CARRY4_DMUX": {
+            "pin_map": {
+                "S3": "S0",
+                "DI3": "0",
+                "CO3": "OUT"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_DX@{site}"
+            ]
+        },
+
+        "CARRY4_AXOR": {
+            "pin_map": {
+                "S0": "0",
+                "CYINIT": "1",
+                "O0": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_AX@{site}"
+            ]
+        },
+        "CARRY4_BXOR": {
+            "pin_map": {
+                "S1": "0",
+                "O1": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_BX@{site}"
+            ]
+        },
+        "CARRY4_CXOR": {
+            "pin_map": {
+                "S2": "0",
+                "O2": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_CX@{site}"
+            ]
+        },
+        "CARRY4_DXOR": {
+            "pin_map": {
+                "S3": "0",
+                "O3": "O"
+            },
+            "default": [
+                "CARRY4@{site}",
+                "CARRY4_DX@{site}"
+            ]
+        },
+
+        "F7[AB]MUX": {
+            "default": [
+                "SELMUX2_1@{site}/{bel}"
+            ]
+        },
+        "F8MUX": {
+            "default": [
+                "SELMUX2_1@{site}/{bel}"
+            ]
+        }
+    },
+
+    "BUFGCTRL": {
+        "BUFGCTRL": {
+            "pin_map": {
+                "I": "I0"
+            },
+            "default": [
+                "BUFGCTRL@BUFGCTRL"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR continues the work towards timing driven routing by importing cell timings from prjxray-db to device resources database of a 7-series device.

Cell timings are stored in SDF format in prjxray-db. The patching script reads them using the `python-sdf-timing` library and populates the data to the device resources structures. Since cell names and instances in those SDF files do not correspond one-to-one with the architecture a manual mapping is needed. For this purpose a JSON file is used which contains the mapping.

The mapping in this PR considers only most common cell types like those inside `SLICE`. Timings for others are either not mapped or not present in prjxray-db.