### PR TITLE
Enable BUFCE route-through for US+ devices and increase max_hops for global buffers

### DIFF
--- a/test_data/xcup_device_config.yaml
+++ b/test_data/xcup_device_config.yaml
@@ -2,6 +2,7 @@
 global_buffer_bels:
 - BUFG
 - BUFGCTRL
+- BUFGCE
 - VCC
 - GND
 # Which cell names are global buffers, and which pins should use dedicated routing resources
@@ -17,12 +18,21 @@ global_buffer_cells:
     pins:
       - name: I0
         guide_placement: true
-        max_hops: 10
+        max_hops: 32
       - name: I1
         guide_placement: true
-        max_hops: 10
+        max_hops: 32
       - name: O
-        force_dedicated_routing: true
+        force_dedicated_routing: true # dedicated routing reaches only up to the interconnect before BUFCE_LEAF
+        max_hops: 32
+  - cell: BUFGCE
+    pins:
+      - name: I
+        guide_placement: true
+        max_hops: 32
+      - name: O
+        force_dedicated_routing: true # dedicated routing reaches only up to the interconnect before BUFCE_LEAF
+        max_hops: 32
 # How should nextpnr lump BELs during analytic placement?
 buckets:
 - bucket: FLIP_FLOPS
@@ -81,7 +91,6 @@ buckets:
 #        using pseudo PIPs through LUTs. For now disable them
 disabled_routethroughs:
   - BUFGCTRL
-  - BUFCE
   - OUTINV
   - A6LUT
   - B6LUT


### PR DESCRIPTION
Required to route PLLE4s to slices through through global buffers.