### PR TITLE
CI: [Rapidwright] Run make compile before make update_jars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         make env
         git clone https://github.com/Xilinx/RapidWright.git $GITHUB_WORKSPACE/env/RapidWright
         make -C "$GITHUB_WORKSPACE/env/RapidWright" update_jars
+        make -C "$GITHUB_WORKSPACE/env/RapidWright" compile
         git clone https://github.com/capnproto/capnproto-java.git $GITHUB_WORKSPACE/env/capnproto-java
         git clone https://github.com/SymbiFlow/fpga-interchange-schema.git $GITHUB_WORKSPACE/env/fpga-interchange-schema
 


### PR DESCRIPTION
https://github.com/Xilinx/RapidWright/commit/d422b0d2bf8b9ebd3e16592703d583565997cb9e removed exucution of `compile` target under `update_jars`. The `compile` target generates `bin/rapidwright_classpath.sh` which is required later.