### PR TITLE
Pin pycapnp library to a working version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest
 psutil
-git+https://github.com/capnproto/pycapnp.git
+pycapnp==1.1.0
 ninja
 pyyaml
 yapf==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     python_requires=">=3.7",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["pycapnp", "python-sat"],
+    install_requires=["pycapnp==1.1.0", "python-sat"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: ISC License",


### PR DESCRIPTION
The CI for the older version fails. It passes after this change.
