### PR TITLE
yosys_json: fix prim lib import

### DIFF
--- a/fpga_interchange/add_prim_lib.py
+++ b/fpga_interchange/add_prim_lib.py
@@ -79,7 +79,7 @@ def main():
             offset = port_data.get('offset', 0)
             upto = port_data.get('upto', False)
 
-            if is_bus(port_data['bits'], offset, upto):
+            if is_bus(port_name, port_data['bits'], offset, upto):
                 end = offset
                 start = offset + len(port_data['bits']) - 1
 


### PR DESCRIPTION
This fixes the following error that is thrown: 

```
Traceback (most recent call last):                                                                                                           
  File "/data/interchange/fpga-interchange-tests/env/conda/envs/fpga-interchange/lib/python3.7/runpy.py", line 193, in _run_module_as_main   
    "__main__", mod_spec)                                                                                                                    
  File "/data/interchange/fpga-interchange-tests/env/conda/envs/fpga-interchange/lib/python3.7/runpy.py", line 85, in _run_code              
    exec(code, run_globals)                                                                                                                  
  File "/data/interchange/fpga-interchange-tests/third_party/python-fpga-interchange/fpga_interchange/add_prim_lib.py", line 133, in <module>                                                                                                                                             
    main()                                                                                                                                   
  File "/data/interchange/fpga-interchange-tests/third_party/python-fpga-interchange/fpga_interchange/add_prim_lib.py", line 82, in main     
    if is_bus(port_data['bits'], offset, upto):                                                                                              
TypeError: is_bus() missing 1 required positional argument: 'upto'    
make[3]: *** [devices/LIFCL-40/CMakeFiles/prims-LIFCL-40-device.dir/build.make:74: devices/LIFCL-40/LIFCL-40.device] Error 1
make[2]: *** [CMakeFiles/Makefile2:9069: devices/LIFCL-40/CMakeFiles/prims-LIFCL-40-device.dir/all] Error 2                                  
make[2]: *** Waiting for unfinished jobs.... 
```

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>